### PR TITLE
Only sleep if a line was not read

### DIFF
--- a/tail.py
+++ b/tail.py
@@ -54,9 +54,9 @@ class Tail(object):
                 line = file_.readline()
                 if not line:
                     file_.seek(curr_position)
+                    time.sleep(s)
                 else:
                     self.callback(line)
-                time.sleep(s)
 
     def register_callback(self, func):
         ''' Overrides default callback function to provided function. '''


### PR DESCRIPTION
If the process writing to the tailed file writes at more than 1 line per second, the reader will never catch up. This should fix the problem.
