### PR TITLE
docs: fix simple typo, registerd -> registered

### DIFF
--- a/tail.py
+++ b/tail.py
@@ -12,7 +12,7 @@ Example:
     t = tail.Tail('file-to-be-followed')
 
     # Register a callback function to be called when a new line is found in the followed file. 
-    # If no callback function is registerd, new lines would be printed to standard out.
+    # If no callback function is registered, new lines would be printed to standard out.
     t.register_callback(callback_function)
 
     # Follow the file with 5 seconds as sleep time between iterations. 


### PR DESCRIPTION
There is a small typo in tail.py.

Should read `registered` rather than `registerd`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md